### PR TITLE
feat: allow specification of a database

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ npm i neo-forte
 * DB_USER
 * DB_PASSWORD
 
+Optionally, you can also use `DB_PASSWORD` if you want to have a session with a particular database.
+
 Those are the credentials that you use to log into the data browser:
   ![sample browser login session](images/neo4jBrowserLogin.jpg)
 
@@ -78,6 +80,7 @@ As suggested above, the simplest approach is to store these variables in your `.
 * DB_URI,
 * DB_USER,
 * DB_PASSWORD
+* [DB_DATABASE]
 
 But you can also generate sessions for as other databases as needed.
 

--- a/src/getDefaultDatabaseInfo.ts
+++ b/src/getDefaultDatabaseInfo.ts
@@ -4,6 +4,7 @@ export function getDefaultDatabaseInfo() {
   const defaultUri = process.env.DB_URI;
   const defaultUser = process.env.DB_USER;
   const defaultPassword = process.env.DB_PASSWORD;
+  const defaultDatabase = process.env.DB_DATABASE;
 
   if (!('DB_URI' in process.env))
     throw new Error('No DB_URI environment variable found, and no databaseInfo provided');
@@ -15,6 +16,7 @@ export function getDefaultDatabaseInfo() {
   return {
     URI: defaultUri,
     USER: defaultUser,
-    PASSWORD: defaultPassword
+    PASSWORD: defaultPassword,
+    DATABASE: defaultDatabase
   };
 }

--- a/src/getSession.ts
+++ b/src/getSession.ts
@@ -28,5 +28,9 @@ export async function getSession(databaseInfo?: DatabaseInfo) {
   } catch (err) {
     throw new Error(`DatabaseError: connectivity verification failed. ${err}`)
   }
-  return driver.session()
+  if (finalDatabaseInfo && finalDatabaseInfo.DATABASE){
+    return driver.session({database: finalDatabaseInfo.DATABASE});
+  } 
+  return driver.session();
+  
 }

--- a/test/unit/getDefaultDatabaseInfo.test.ts
+++ b/test/unit/getDefaultDatabaseInfo.test.ts
@@ -25,7 +25,8 @@ test.serial('getDefaultDatabaseInfo', t => {
     const expected = {
         URI: tempUri,
         USER: tempUser,
-        PASSWORD: tempPassword
+        PASSWORD: tempPassword,
+        DATABASE: undefined
     }
     const result = getDefaultDatabaseInfo()
     t.deepEqual(result, expected)

--- a/test/unit/getSession.test.ts
+++ b/test/unit/getSession.test.ts
@@ -12,9 +12,18 @@ import test from 'ava'
 const testURI = 'testDB_URI'
 const testUSER = 'testDB_USER'
 const testPASSWORD = 'testDB_PASSWORD'
+const testDATABASE = 'testDB_DATABASE'
 
 
 const databaseInfo = {
+    URI: testURI,
+    USER: testUSER,
+    PASSWORD: testPASSWORD,
+    DATABASE: testDATABASE
+}
+
+
+const databaseInfoNoDatabase = {
     URI: testURI,
     USER: testUSER,
     PASSWORD: testPASSWORD
@@ -65,6 +74,11 @@ const { getSession } = proxyquire('../../src/getSession', {
 
 test('getSession', async t => {
     const result = await getSession(databaseInfo)
+    t.is(result, fakeSession);
+})
+
+test('getSession without database', async t => {
+    const result = await getSession(databaseInfoNoDatabase)
     t.is(result, fakeSession);
 })
 


### PR DESCRIPTION
Can now store DB_DATABASE in .env or specify a database in DatabaseInfo and session will be made to
it.

fix #27
